### PR TITLE
Display book page thumbnails with annotation indicators

### DIFF
--- a/winthrop/books/templates/books/book_detail.html
+++ b/winthrop/books/templates/books/book_detail.html
@@ -25,9 +25,9 @@
                 <img class="ui image" src="{% iiif_image book.thumbnail height=218 %}"
                     srcset="{% iiif_image book.thumbnail height=436 %} 2x"
                     alt="{{ book.thumbnail_label }}" title="{{ book.thumbnail_label }}"/>
-                <button class="ui large basic button">
+                <a class="ui large basic button" href="{% url 'books:pages' book.slug %}">
                     View Book
-                </button>
+                </a>
             {% endif %}
         </div>
         <div class="metadata">

--- a/winthrop/books/templates/books/book_page_thumbnails.html
+++ b/winthrop/books/templates/books/book_page_thumbnails.html
@@ -7,12 +7,38 @@
 {% block content %}
 <div class="ui container">
  <a href="{{ book.get_absolute_url }}">&lt; {{ book.short_title }}</a>
-</div>
-<div class="ui container">
+
+ {# legend for annotation markers (icons preliminary only) #}
+ <div class="ui label">
+  <i class="font icon"></i> Textual annotation
+ </div>
+ <div class="ui label">
+  <i class="image icon"></i> Graphical annotation
+ </div>
+
+<div class="ui horizontal divider"></div>
+
+<div class="ui grid">
     {% for page in pages %}
-        <img class="ui image left floated" src="{% iiif_image page.iiif_image_id height=218 %}"
+     <div class="two wide column">
+        <img class="ui image" src="{% iiif_image page.iiif_image_id height=218 %}"
             srcset="{% iiif_image page.iiif_image_id height=436 %} 2x"
             alt="{{ page.label }}" title="{{ page.label }}"/>
+    {# TODO: this may be too slow... need to annotate the canvas queryset instead? #}
+        {% if page.textual_annotation or page.graphical_annotation %}
+        <div class="floating ui label">
+          {% if page.textual_annotation %}
+            <i class="font icon item"
+            title="{{ page.textual_annotation }} textual annotation{{ page.textual_annotation |pluralize}}"></i>
+          {% endif %}
+        {% if page.graphical_annotation %}
+           <i class="image icon item"
+            title="{{ page.graphical_annotation }} graphical annotation{{ page.graphical_annotation |pluralize}}"></i>
+        {% endif %}
+          </div>
+        {% endif %}
+    </div>
     {% endfor %}
+</div>
 </div>
 {% endblock %}

--- a/winthrop/books/templates/books/book_page_thumbnails.html
+++ b/winthrop/books/templates/books/book_page_thumbnails.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block page-subtitle %}Pages | {{ book.short_title }} | Books | {% endblock %}
+
+{% block page-context-id %}book-detail{% endblock %}
+
+{% block content %}
+<div class="ui container">
+ <a href="{{ book.get_absolute_url }}">&lt; {{ book.short_title }}</a>
+</div>
+<div class="ui container">
+    {% for page in pages %}
+        <img class="ui image left floated" src="{% iiif_image page.iiif_image_id height=218 %}"
+            srcset="{% iiif_image page.iiif_image_id height=436 %} 2x"
+            alt="{{ page.label }}" title="{{ page.label }}"/>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/winthrop/books/templates/books/book_page_thumbnails.html
+++ b/winthrop/books/templates/books/book_page_thumbnails.html
@@ -24,7 +24,6 @@
         <img class="ui image" src="{% iiif_image page.iiif_image_id height=218 %}"
             srcset="{% iiif_image page.iiif_image_id height=436 %} 2x"
             alt="{{ page.label }}" title="{{ page.label }}"/>
-    {# TODO: this may be too slow... need to annotate the canvas queryset instead? #}
         {% if page.textual_annotation or page.graphical_annotation %}
         <div class="floating ui label">
           {% if page.textual_annotation %}

--- a/winthrop/books/urls.py
+++ b/winthrop/books/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^$', views.BookListView.as_view(), name='list'),
     url(r'^facets/$', views.BookFacetJSONView.as_view(), name='facets'),
     url(r'^(?P<slug>[-\w]+)/$', views.BookDetailView.as_view(), name='detail'),
+    url(r'^(?P<slug>[-\w]+)/pages/$', views.BookPageView.as_view(), name='pages'),
     url(r'^autocomplete/publisher/$', staff_member_required(views.PublisherAutocomplete.as_view()),
         name='publisher-autocomplete'),
     url(r'^autocomplete/canvas/$', staff_member_required(views.CanvasAutocomplete.as_view()),

--- a/winthrop/books/views.py
+++ b/winthrop/books/views.py
@@ -1,7 +1,7 @@
 from dal import autocomplete
 from django.core.validators import ValidationError
 from django.db.models import Q, Count
-from django.http import JsonResponse
+from django.http import JsonResponse, Http404
 from django.views.generic import ListView, DetailView
 from django.shortcuts import get_object_or_404
 from djiffy.models import Canvas
@@ -271,9 +271,12 @@ class BookPageView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # add book to context for title display and link to main book page
-        # should 404 if book does not exist
-        # TODO: 404 if book is not digitized
-        context['book'] = get_object_or_404(Book, slug=self.kwargs['slug'])
+        # 404 if book does not exist or does not have a digital editon
+        book = get_object_or_404(Book, slug=self.kwargs['slug'])
+        if not book.digital_edition:
+            raise Http404
+
+        context['book'] = book
         return context
 
 

--- a/winthrop/books/views.py
+++ b/winthrop/books/views.py
@@ -3,6 +3,7 @@ from django.core.validators import ValidationError
 from django.db.models import Q
 from django.http import JsonResponse
 from django.views.generic import ListView, DetailView
+from django.shortcuts import get_object_or_404
 from djiffy.models import Canvas
 from SolrClient.exceptions import SolrError
 
@@ -252,6 +253,19 @@ class BookDetailView(DetailView, LastModifiedMixin):
                 return self.solr_timestamp_to_datetime(psq[0]['last_modified'])
         except SolrError:
             pass
+
+class BookPageView(ListView):
+    model = Canvas
+    template_name = 'books/book_page_thumbnails.html'
+    context_object_name = 'pages'
+
+    def get_queryset(self):
+        return super().get_queryset().filter(manifest__book__slug=self.kwargs['slug'])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['book'] = get_object_or_404(Book, slug=self.kwargs['slug'])
+        return context
 
 
 class PublisherAutocomplete(autocomplete.Select2QuerySetView):


### PR DESCRIPTION
New view and template to display digitized page images with annotation indicators. Uses queryset annotation to efficiently get counts of textual and graphical annotations for each Canvas object in the set.  Display is provisional, using semantic-ui built ins.

Unit tests for the actual view are fairly minimal, wasn't sure how in depth to go.