### PR TITLE
Feature/book index relateds

### DIFF
--- a/winthrop/books/models.py
+++ b/winthrop/books/models.py
@@ -246,6 +246,14 @@ class Book(Notable, Indexable):
         logger.debug('creator change, reindexing %s', instance.book)
         instance.book.index(params={'commitWithin': 3000})
 
+    def handle_subject_save(sender, instance, **kwargs):
+        '''signal handler for change to subject name'''
+        if instance.name_changed:
+            logger.debug('subject named changed, reindexing %d books',
+                         instance.book_set.count())
+            Indexable.index_items(instance.book_set.all(),
+                                  params={'commitWithin': 3000})
+
     #: index dependencies, to update when related items are changed
     index_depends_on = {
         # author name
@@ -257,6 +265,9 @@ class Book(Notable, Indexable):
             'post_save': handle_creator_change,
             'post_delete': handle_creator_change,
         },
+        'subjects': {
+            'post_save': handle_subject_save,
+        }
     }
 
     def index_id(self):

--- a/winthrop/books/models.py
+++ b/winthrop/books/models.py
@@ -240,7 +240,6 @@ class Book(Notable, Indexable):
         :class:`winthrop.books.models.Book` that are subclasses of
         :class:`winthrop.common.models.Named`.'''
         if instance.name_changed:
-            logger.debug('foo')
             logger.debug(
                 '%s (%s) name changed, reindexing %d books',
                 instance,

--- a/winthrop/books/models.py
+++ b/winthrop/books/models.py
@@ -225,13 +225,39 @@ class Book(Notable, Indexable):
             logger.debug('person save, reindexing %d book(s)', instance.book_set.count())
             Indexable.index_items(instance.book_set.all(), params={'commitWithin': 3000})
 
-    def handle_person_delete(sender, instance, **kwargs):
-        '''signal handler for person delete; reindex books'''
+    def handle_creator_change(sender, instance, **kwargs):
+        '''signal handler for creator save or delete; reindex to get any creator changes'''
+        # same behavior for save or delete
+        logger.debug('creator change, reindexing %s', instance.book)
+        instance.book.index(params={'commitWithin': 3000})
+
+    def handle_named_save(sender, instance, **kwargs):
+        '''Signal handler for name changes to m2ms on
+        :class:`winthrop.books.models.Book` that are subclasses of
+        :class:`winthrop.common.models.Named`.'''
+        if instance.name_changed:
+            logger.debug('foo')
+            logger.debug(
+                '%s (%s) name changed, reindexing %d books',
+                instance,
+                instance.__class__.__name__,
+                instance.book_set.count()
+            )
+            Indexable.index_items(instance.book_set.all(),
+                                  params={'commitWithin': 3000})
+
+    def handle_related_delete(sender, instance, **kwargs):
+        '''Signal handler for deletions on m2m models on
+        :class:`winthrop.books.models.Book`'''
 
         # get a list of ids for collected works before clearing them
         book_ids = instance.book_set.values_list('id', flat=True)
 
-        logger.debug('person delete, reindexing %d book(s)', len(book_ids))
+        logger.debug(
+            '%s delete, reindexing %d book(s)',
+            instance.__class__.__name__,
+            len(book_ids),
+        )
         # find the items based on the list of ids to reindex
         books = Book.objects.filter(id__in=list(book_ids))
 
@@ -240,34 +266,26 @@ class Book(Notable, Indexable):
         instance.book_set.clear()
         Indexable.index_items(books, params={'commitWithin': 3000})
 
-    def handle_creator_change(sender, instance, **kwargs):
-        '''signal handler for creator save or delete; reindex to get any creator changes'''
-        # same behavior for save or delete
-        logger.debug('creator change, reindexing %s', instance.book)
-        instance.book.index(params={'commitWithin': 3000})
-
-    def handle_subject_save(sender, instance, **kwargs):
-        '''signal handler for change to subject name'''
-        if instance.name_changed:
-            logger.debug('subject named changed, reindexing %d books',
-                         instance.book_set.count())
-            Indexable.index_items(instance.book_set.all(),
-                                  params={'commitWithin': 3000})
-
     #: index dependencies, to update when related items are changed
     index_depends_on = {
         # author name
         'contributors': {
             'post_save': handle_person_save,
-            'pre_delete': handle_person_delete,
+            'pre_delete': handle_related_delete,
         },
         'creator_set': {
             'post_save': handle_creator_change,
             'post_delete': handle_creator_change,
         },
         'subjects': {
-            'post_save': handle_subject_save,
-        }
+            'post_save': handle_named_save,
+            'pre_delete': handle_related_delete,
+        },
+        'languages': {
+            'post_save': handle_named_save,
+            'pre_delete': handle_related_delete,
+        },
+        
     }
 
     def index_id(self):

--- a/winthrop/books/tests/test_book_models.py
+++ b/winthrop/books/tests/test_book_models.py
@@ -236,11 +236,11 @@ class TestBook(TestCase):
         assert kwargs['params'] == {'commitWithin': 3000}
 
     @patch.object(Indexable, 'index_items')
-    def test_handle_person_delete(self, mock_index_items):
+    def test_handle_related_delete(self, mock_index_items):
         author = Person.objects.all().first()
         book = Book.objects.filter(contributors=author).first()
 
-        Book.handle_person_delete(Mock(), author)
+        Book.handle_related_delete(Mock(), author)
 
         assert author.book_set.count() == 0
         args, kwargs = mock_index_items.call_args
@@ -249,7 +249,7 @@ class TestBook(TestCase):
         assert kwargs['params'] == {'commitWithin': 3000}
 
     @patch.object(Indexable, 'index_items')
-    def test_handle_subject_save(self, mock_index_items):
+    def test_handle_named_save(self, mock_index_items):
         # - create a book with a subject attached
         subject = Subject.objects.all().first()
         book = Book.objects.first()
@@ -259,11 +259,11 @@ class TestBook(TestCase):
             is_primary=True,
         )
         # no change in name, not called
-        Book.handle_subject_save(Mock(), subject)
+        Book.handle_named_save(Mock(), subject)
         assert not mock_index_items.called
         subject.name = 'Test'
 
-        Book.handle_subject_save(Mock(), subject)
+        Book.handle_named_save(Mock(), subject)
         args, kwargs = mock_index_items.call_args
         assert isinstance(args[0], QuerySet)
         assert book in args[0]

--- a/winthrop/books/tests/test_book_models.py
+++ b/winthrop/books/tests/test_book_models.py
@@ -248,6 +248,27 @@ class TestBook(TestCase):
         assert book in args[0]
         assert kwargs['params'] == {'commitWithin': 3000}
 
+    @patch.object(Indexable, 'index_items')
+    def test_handle_subject_save(self, mock_index_items):
+        # - create a book with a subject attached
+        subject = Subject.objects.all().first()
+        book = Book.objects.first()
+        BookSubject.objects.create(
+            subject=subject,
+            book=book,
+            is_primary=True,
+        )
+        # no change in name, not called
+        Book.handle_subject_save(Mock(), subject)
+        assert not mock_index_items.called
+        subject.name = 'Test'
+
+        Book.handle_subject_save(Mock(), subject)
+        args, kwargs = mock_index_items.call_args
+        assert isinstance(args[0], QuerySet)
+        assert book in args[0]
+        assert kwargs['params'] == {'commitWithin': 3000}
+
     def test_index_id(self):
         book = Book.objects.all().first()
         assert book.index_id() == 'book:%d' % book.pk

--- a/winthrop/books/tests/test_book_models.py
+++ b/winthrop/books/tests/test_book_models.py
@@ -179,7 +179,6 @@ class TestBook(TestCase):
         book = Book()
         assert not book.translators()
 
-
     def test_add_author(self):
         de_christelicke = Book.objects.get(short_title__contains="De Christelicke")
         abelin = Person.objects.get(authorized_name="Abelin, Johann Philipp")

--- a/winthrop/common/models.py
+++ b/winthrop/common/models.py
@@ -1,12 +1,16 @@
 from django.db import models
 from django.core.exceptions import ValidationError
 
+
 # abstract models with common fields to be
 # used as mix-ins
-
 class Named(models.Model):
     '''Abstract model with a 'name' field; by default, name is used as
     the string display.'''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__initial = self.__dict__.copy()
 
     #: unique name (required)
     name = models.CharField(max_length=255, unique=True)
@@ -17,6 +21,12 @@ class Named(models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def name_changed(self):
+        '''Determine if the name of an object has changed on
+        current instance'''
+        return self.name != self.__initial['name']
 
 
 class Notable(models.Model):
@@ -73,4 +83,3 @@ class DateRange(models.Model):
         if self.start_year and self.end_year and \
                 not self.end_year >= self.start_year:
             raise ValidationError('End year must be after start year')
-

--- a/winthrop/common/tests/test_common_models.py
+++ b/winthrop/common/tests/test_common_models.py
@@ -11,6 +11,18 @@ class TestNamed(TestCase):
         named_obj = Named(name='foo')
         assert str(named_obj) == 'foo'
 
+    def test_name_changed(self):
+        named_obj = Named(name='foo')
+        # should be the same
+        assert not named_obj.name_changed
+        named_obj.name = 'bar'
+        # should now register that the two attributes are different
+        assert named_obj.name_changed
+        # simulate a reload of initial, since abstract models can't be saved
+        named_obj.__init__()
+        assert not named_obj.name_changed
+
+
 
 class TestNotable(TestCase):
 

--- a/winthrop/common/tests/test_signals.py
+++ b/winthrop/common/tests/test_signals.py
@@ -44,19 +44,10 @@ class TestIndexableSignalHandler(TestCase):
         # - post save
         assert ref(Book.handle_person_save) in post_save_handlers
         assert ref(Book.handle_named_save) in post_save_handlers
-        assert ref(Book.handle_creator_change) in post_save_handlers
+        assert ref(Book.handle_related_change) in post_save_handlers
 
         # - post delete
-        assert ref(Book.handle_creator_change) in post_del_handlers
-
-
-
-        # testing related handlers based on model config
-        # in PPA, NOT YET USED here
-        # pre_save_handlers = [item[1] for item in models.signals.pre_save.receivers]
-        # assert ref(DigitizedWork.handle_collection_save) in pre_save_handlers
-        # pre_del_handlers = [item[1] for item in models.signals.pre_delete.receivers]
-        # assert ref(DigitizedWork.handle_collection_delete) in pre_del_handlers
+        assert ref(Book.handle_related_change) in post_del_handlers
 
     @pytest.mark.django_db
     def test_handle_save(self):

--- a/winthrop/common/tests/test_signals.py
+++ b/winthrop/common/tests/test_signals.py
@@ -31,9 +31,25 @@ class TestIndexableSignalHandler(TestCase):
         post_del_handlers = [item[1] for item in models.signals.post_delete.receivers]
         assert ref(IndexableSignalHandler.handle_delete) in post_del_handlers
         # many to many
-        # NOT YET IN USE here
-        # m2m_handlers = [item[1] for item in models.signals.m2m_changed.receivers]
-        # assert ref(IndexableSignalHandler.handle_relation_change) in m2m_handlers
+        m2m_handlers = [item[1] for item in models.signals.m2m_changed.receivers]
+        assert ref(IndexableSignalHandler.handle_relation_change) in m2m_handlers
+
+        # check Wintrhop specific handlers, some reused definitions from
+        # above
+
+        # - pre delete
+        pre_del_handlers = [item[1] for item in models.signals.pre_delete.receivers]
+        assert ref(Book.handle_person_delete) in pre_del_handlers
+
+        # - post save
+        assert ref(Book.handle_person_save) in post_save_handlers
+        assert ref(Book.handle_subject_save) in post_save_handlers
+        assert ref(Book.handle_creator_change) in post_save_handlers
+
+        # - post delete
+        assert ref(Book.handle_creator_change) in post_del_handlers
+
+
 
         # testing related handlers based on model config
         # in PPA, NOT YET USED here

--- a/winthrop/common/tests/test_signals.py
+++ b/winthrop/common/tests/test_signals.py
@@ -39,11 +39,11 @@ class TestIndexableSignalHandler(TestCase):
 
         # - pre delete
         pre_del_handlers = [item[1] for item in models.signals.pre_delete.receivers]
-        assert ref(Book.handle_person_delete) in pre_del_handlers
+        assert ref(Book.handle_related_delete) in pre_del_handlers
 
         # - post save
         assert ref(Book.handle_person_save) in post_save_handlers
-        assert ref(Book.handle_subject_save) in post_save_handlers
+        assert ref(Book.handle_named_save) in post_save_handlers
         assert ref(Book.handle_creator_change) in post_save_handlers
 
         # - post delete

--- a/winthrop/common/tests/test_signals.py
+++ b/winthrop/common/tests/test_signals.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.test import TestCase, override_settings
 import pytest
 
-from winthrop.books.models import Book, Creator, CreatorType
+from winthrop.books.models import Book, Creator, CreatorType, Subject, BookSubject
 from winthrop.people.models import Person
 from winthrop.common.signals import IndexableSignalHandler
 
@@ -103,6 +103,13 @@ class TestIndexableSignalHandler(TestCase):
             mockindex.reset_mock()
             IndexableSignalHandler.handle_relation_change(Mock(), book, 'pre_remove')
             mockindex.assert_not_called()
+
+            # test with another of the change related sets, to ensure that
+            # different types follow same logic
+            mockindex.reset_mock()
+            subj = Subject.objects.first()
+            BookSubject.objects.create(book=book, subject=subj, is_primary=True)
+            mockindex.assert_called_with(params=IndexableSignalHandler.index_params)
 
         # non-indexable object should be ignored
         nonindexable = Mock()


### PR DESCRIPTION
This pull request addresses #111 and add signal indexing for:

- subjects related to books
- languages related to books

as well as their related `__set` managers to account for direct creation of through objects.

It also refactors methods to create common handlers wherever possible for m2m fields with explicit through models and subclasses of `Named`.