### PR TITLE
Feature/pagination

### DIFF
--- a/sitemedia/js/components/Pagination.js
+++ b/sitemedia/js/components/Pagination.js
@@ -1,0 +1,46 @@
+import { mapState, mapGetters } from 'vuex'
+
+export default Vue.component('Pagination', {
+    template: `
+    <div class="pagination">
+        <div class="page-controls">
+            <a rel="prev" is="sui-button" icon="chevron left" @click="previous" :disabled="current < 2"></a>
+            <a is="sui-button" @click="go(1)" v-if="current > 3">1</a>
+            <sui-icon name="ellipsis horizontal" v-if="current > 4 && total > 6"/>
+            <a is="sui-button" v-for="page in displayRange" @click="go(page)" :active="current === page">{{ page }}</a>
+            <sui-icon name="ellipsis horizontal" v-if="current < total - 3 && total > 6"/>
+            <a is="sui-button" @click="go(total)" v-if="current < total - 2">{{ total }}</a>
+            <a rel="next" is="sui-button" icon="chevron right" @click="next" :disabled="current > total - 1"></a>
+        </div>
+    </div>
+    `,
+    computed: {
+        ...mapState('pages', ['current', 'total']),
+        ...mapGetters('pages', ['range']),
+        displayRange() {
+            let output = []
+            this.range.forEach(number => {
+                // always show current page
+                if (number == this.current) output.push(number)
+                // for current page 1 or 2, display first 5
+                else if (this.current <= 2 && number <= 5) output.push(number)
+                // for current page last or next to last, display last 5
+                else if (this.current + 1 >= this.total && number >= this.total - 4) output.push(number)
+                // show the two numbers before and after the current page
+                else if (this.current + 2 >= number && this.current - 2 <= number) output.push(number)
+            })
+            return output
+        },
+    },
+    methods: {
+        go(page) {
+            this.$store.dispatch('pages/go', page)
+        },
+        next() {
+            this.current < this.total && this.$store.dispatch('pages/next')
+        },
+        previous() {
+            this.current > 1 && this.$store.dispatch('pages/previous')
+        },
+    },
+})

--- a/sitemedia/js/components/SearchForm.js
+++ b/sitemedia/js/components/SearchForm.js
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty'
 import { mapGetters, mapActions, mapState, mapMutations } from 'vuex'
 
 export default Vue.component('SearchForm', {
@@ -41,8 +40,9 @@ export default Vue.component('SearchForm', {
                     @click="clearFacets">
                     Clear All</label>
             </sui-segment>
-            <sui-segment inverted>
+            <sui-segment inverted class="result-controls">
                 <slot name="sort"></slot>
+                <slot name="pagination"></slot>
             </sui-segment>
         </form>
     </div>`,
@@ -73,17 +73,18 @@ export default Vue.component('SearchForm', {
             'updateURL',
         ]),
         ...mapMutations([
-            'changeSort',
+            'results/sort',
+            'results/setEndpoint',
             'setFacetsEndpoint',
-            'setResultsEndpoint',
         ]),
     },
     created() {
         this.setFacetsEndpoint(this.facetsEndpoint) // set endpoints
-        this.setResultsEndpoint(this.resultsEndpoint)
+        this['results/setEndpoint'](this.resultsEndpoint)
         let initialState = {
             ...this.route.query,
             sort: this.route.query.sort || 'author_asc', // default if none selected
+            page: this.route.query.page || 1 // default if none selected
         }
         this.addFacets(initialState).then(() => this.setFormState(initialState)) // initialize form
     }

--- a/sitemedia/js/components/SearchForm.js
+++ b/sitemedia/js/components/SearchForm.js
@@ -5,7 +5,7 @@ export default Vue.component('SearchForm', {
     <div class="books-search">
         <sui-container textAlign="center" text>
             <h4 is="sui-header" class="results-count">
-            Displaying {{ totalResults }} {{ totalResults | pluralize(resource) }}
+            Displaying {{ total }} {{ total | pluralize(resource) }}
             </h4>
         </sui-container>
         <form class="search-form ui form">
@@ -52,10 +52,8 @@ export default Vue.component('SearchForm', {
         facetsEndpoint: String,
     },
     computed: {
-        ...mapState([
-            'route',
-            'totalResults',
-        ]),
+        ...mapState('results', ['total']),
+        ...mapState(['route']),
         ...mapGetters([
             'activeFacetChoices',
             'activeRangeFacets',
@@ -65,7 +63,6 @@ export default Vue.component('SearchForm', {
     methods: {
         ...mapActions([
             'addFacets',
-            'updateResults',
             'clearFacets',
             'toggleFacetChoice',
             'clearRangeFacet',

--- a/sitemedia/js/components/SearchResults.js
+++ b/sitemedia/js/components/SearchResults.js
@@ -1,10 +1,6 @@
 import { mapState } from 'vuex'
 
 export default Vue.component('SearchResults', {
-    template: `<div class="search-results" v-html="results"></div>`,
-    computed: {
-        ...mapState([
-            'results',
-        ]),
-    }
+    template: `<div class="search-results" v-html="html"></div>`,
+    computed: mapState('results', ['html']),
 })

--- a/sitemedia/js/components/SearchSort.js
+++ b/sitemedia/js/components/SearchSort.js
@@ -7,16 +7,14 @@ export default Vue.component('SearchSort', {
         <sui-dropdown
             :value="activeSort"
             :options="options"
-            @input="changeSort($event)"
+            @input="sort($event)"
             selection
         />
     </div>
     `,
     computed: {
-        ...mapState([
-            'activeSort',
-            'keywordQuery'
-        ]),
+        ...mapState(['keywordQuery']),
+        ...mapState('results', ['activeSort']),
         options() { // array of props for `sui-dropdown-item`s inside dropdown
             return [
                 {
@@ -44,8 +42,6 @@ export default Vue.component('SearchSort', {
         },
     },
     methods: {
-        ...mapActions([
-            'changeSort'
-        ]),
+        ...mapActions('results', ['sort']),
     },
 })

--- a/sitemedia/js/search.js
+++ b/sitemedia/js/search.js
@@ -11,6 +11,7 @@ import SearchForm from './components/SearchForm'
 import TextFacet from './components/TextFacet'
 import RangeFacet from './components/RangeFacet'
 import SearchSort from './components/SearchSort'
+import Pagination from './components/Pagination'
 import SearchResults from './components/SearchResults'
 
 const unsync = sync(store, router)
@@ -29,6 +30,7 @@ $(() => {
             TextFacet,
             RangeFacet,
             SearchSort,
+            Pagination,
             SearchResults,
         },
         beforeDestroy() {

--- a/sitemedia/js/store/actions.js
+++ b/sitemedia/js/store/actions.js
@@ -35,6 +35,7 @@ export default {
      */
     async toggleFacetChoice ({ commit, dispatch }, choice) {
         commit('toggleFacetChoice', choice)
+        commit('pages/go', 1)
         await dispatch('updateFacets')
         await dispatch('results/update')
         dispatch('updateURL')
@@ -48,6 +49,7 @@ export default {
      */
     async editRangeFacetMin ({ commit, dispatch }, facet) {
         commit('editRangeFacetMin', facet)
+        commit('pages/go', 1)
         await dispatch('updateFacets')
         await dispatch('results/update')
         dispatch('updateURL')
@@ -61,6 +63,7 @@ export default {
      */
     async editRangeFacetMax ({ commit, dispatch }, facet) {
         commit('editRangeFacetMax', facet)
+        commit('pages/go', 1)
         await dispatch('updateFacets')
         await dispatch('results/update')
         dispatch('updateURL')
@@ -74,6 +77,7 @@ export default {
     async clearFacets ({ commit, dispatch }) {
         commit('clearFacetChoices')
         commit('clearRangeFacets')
+        commit('pages/go', 1)
         await dispatch('updateFacets')
         await dispatch('results/update')
         dispatch('updateURL')
@@ -87,6 +91,7 @@ export default {
      */
     async setKeywordQuery({ state, commit, dispatch }, query) {
         commit('setKeywordQuery', query)
+        commit('pages/go', 1)
         if (!query && state.activeSort === 'relevance') { // if the query was deleted and we were on relevance...
             commit('results/sort', 'author_asc') // ...switch to author a-z
         }

--- a/sitemedia/js/store/actions.js
+++ b/sitemedia/js/store/actions.js
@@ -115,7 +115,7 @@ export default {
         commit('setFacetChoices', facets)
         commit('setKeywordQuery', query)
         commit('results/sort', sort)
-        commit('pages/go', page)
+        commit('pages/go', parseInt(page))
         await dispatch('updateFacets')
         await dispatch('results/update')
     },

--- a/sitemedia/js/store/getters.js
+++ b/sitemedia/js/store/getters.js
@@ -97,22 +97,6 @@ export default {
     },
 
     /**
-     * Returns a function that will create a URL to pass to fetch()
-     * that will return HTML result data from Django.
-     * 
-     * Resulting function takes an optional argument that allows it to
-     * generate a URL for any form state; default is the current state.
-     *
-     * @param {Object} state application state
-     * @param {Object} getters other getter functions
-     * @returns {Function} URL function
-     */
-    resultsPath: (state, getters) => formState => {
-        if (formState) return `${state.resultsEndpoint}?${querystring.stringify(formState)}`
-        else return `${state.resultsEndpoint}?${querystring.stringify(getters.formState)}`
-    },
-
-    /**
      * Returns a function that will retrieve the current minimum and
      * maximum values from a range facet by name.
      *

--- a/sitemedia/js/store/getters.js
+++ b/sitemedia/js/store/getters.js
@@ -74,8 +74,9 @@ export default {
         return {
             ...getters.activeFacets,
             ...getters.activeRangeFacetValues,
-            ...(state.activeSort && { 'sort': state.activeSort }), // we only add this property if it's defined
-            ...(state.keywordQuery && { 'query': state.keywordQuery }), // same here
+            ...(state.keywordQuery && { 'query': state.keywordQuery }), // only add this if it's defined
+            sort: state.results.activeSort,
+            page: state.pages.current,
         }
     },
 

--- a/sitemedia/js/store/index.js
+++ b/sitemedia/js/store/index.js
@@ -11,12 +11,8 @@ Vue.use(Vuex)
 const state = {
 	facets: [],
 	facetChoices: [],
-	// totalResults: 0,
-	// results: '',
-	// activeSort: '',
     keywordQuery: '',
     facetsEndpoint: '',
-    // resultsEndpoint: '',
 }
 
 export default new Vuex.Store({

--- a/sitemedia/js/store/index.js
+++ b/sitemedia/js/store/index.js
@@ -3,22 +3,29 @@ import mutations from './mutations'
 import actions from './actions'
 import getters from './getters'
 
+import pages from './modules/pages'
+import results from './modules/results'
+
 Vue.use(Vuex)
 
 const state = {
 	facets: [],
 	facetChoices: [],
-	totalResults: 0,
-	results: '',
-	activeSort: '',
+	// totalResults: 0,
+	// results: '',
+	// activeSort: '',
     keywordQuery: '',
     facetsEndpoint: '',
-    resultsEndpoint: '',
+    // resultsEndpoint: '',
 }
 
 export default new Vuex.Store({
 	state,
 	mutations,
 	actions,
-	getters,
+    getters,
+    modules: {
+        pages: pages,
+        results: results,
+    }
 })

--- a/sitemedia/js/store/modules/facets.js
+++ b/sitemedia/js/store/modules/facets.js
@@ -1,0 +1,36 @@
+import { reduceFacets } from '../../utilities'
+
+export default {
+    namespaced: true,
+    state: {
+        facets: [],
+        choices: [],
+        endpoint: '',
+    },
+    mutations: {
+        add: (state, facets) => facets.forEach(state.facets.push), // add a list of facets
+        addChoices: (state, choices) => choices.forEach(state.choices.push), // add a list of facet choices
+        setEndpoint: (state, endpoint) => state.endpoint = endpoint, // update the endpoint at which to fetch data
+    },
+    getters: {
+        text: state => state.facets.filter(facet => facet.type === 'text'),
+        range: state => state.facets.filter(facet => facet.type === 'range'),
+        activeChoices: state => state.choices.filter(choice => choice.active),
+        textAsObject: (state, getters) => getters.activeChoices.reduce(reduceFacets, {}),
+        /**
+         * Returns a function that accepts form state and will create
+         * a URL to pass to fetch() that will return facet data.
+         *
+         * @param {Object} state application state
+         */
+        path: state => formState => `${state.endpoint}?${querystring.stringify(formState)}`
+    },
+    modules: {
+        text: {
+            getters: {
+                all: state => 
+                active: (state, getters) => getters.text.filter()
+            }
+        }
+    }
+}

--- a/sitemedia/js/store/modules/pages.js
+++ b/sitemedia/js/store/modules/pages.js
@@ -1,0 +1,30 @@
+export default {
+    namespaced: true,
+    state: {
+        current: 1,
+        total: 0,
+    },
+    mutations: {
+        next: state => state.current++, // go to the next page
+        previous: state => state.current--, // go to the previous page
+        go: (state, page) => state.current = page, // go to a given page
+        setTotal: (state, total) => state.total = total, // set the total number of pages
+    },
+    actions: {
+        next: async ({ commit, dispatch }) => { // go to the next page and request results
+            commit('next')
+            await dispatch('results/update', null, { root: true })
+        }, 
+        previous: async ({ commit, dispatch }) => { // go to the previous page and request results
+            commit('previous')
+            await dispatch('results/update', null, { root: true })
+        }, 
+        go: async ({ commit, dispatch }, page) => { // go to a given page and request results
+            commit('go', page)
+            await dispatch('results/update', null, { root: true })
+        },
+    },
+    getters: {
+        range: state => [...Array(state.total + 1).keys()].slice(1), // [1, 2, ... total]
+    },
+}

--- a/sitemedia/js/store/modules/results.js
+++ b/sitemedia/js/store/modules/results.js
@@ -16,7 +16,7 @@ export default {
         setEndpoint: (state, endpoint) => state.endpoint = endpoint, // update the endpoint at which to fetch results
     },
     actions: {
-        update: async ({ commit, getters, rootGetters }) => {
+        update: async ({ commit, dispatch, getters, rootGetters }) => {
             await fetch(getters.path(rootGetters.formState), ajax) // get result data from the server
                 .then(res => res.text())
                 .then(html => {
@@ -25,13 +25,18 @@ export default {
                     commit('setTotal', data.total) // set the total results
                     commit('pages/setTotal', data.pages, { root: true }) // root:true necessary to use other module
                     commit('update', html) // update the actual result HTML
+                    dispatch('updateURL', null, { root: true }) // update the URL
                 })
         },
-        sort: async ({ commit, getters, rootGetters }, sort) => {
+        sort: async ({ commit, dispatch, getters, rootGetters }, sort) => {
             commit('sort', sort) // change the sort type
+            commit('pages/go', 1) // go back to the first page
             await fetch(getters.path(rootGetters.formState), ajax) // get result data from the server
                 .then(res => res.text()) // we don't need the pagination data because it stays the same
-                .then(html => commit('update', html)) // just update result HTML
+                .then(html => {
+                    commit('update', html) // just update result HTML
+                    dispatch('updateURL', null, { root: true }) // and the URL
+                })
         },
     },
     getters: {

--- a/sitemedia/js/store/modules/results.js
+++ b/sitemedia/js/store/modules/results.js
@@ -1,0 +1,40 @@
+import querystring from 'query-string'
+import { ajax, parser } from '../../utilities'
+
+export default {
+    namespaced: true,
+    state: {
+        total: 0,
+        activeSort: '',
+        html: '',
+        endpoint: '',
+    },
+    mutations: {
+        sort: (state, sort) => state.activeSort = sort, // change active sort type
+        update: (state, html) => state.html = html, // update the stored result HTML
+        setTotal: (state, total) => state.total = total, // update the total number of results
+        setEndpoint: (state, endpoint) => state.endpoint = endpoint, // update the endpoint at which to fetch results
+    },
+    actions: {
+        update: async ({ commit, getters, rootGetters }) => {
+            await fetch(getters.path(rootGetters.formState), ajax) // get result data from the server
+                .then(res => res.text())
+                .then(html => {
+                    let doc = parser.parseFromString(html, 'text/html') // parse the return HTML
+                    let data = JSON.parse(doc.getElementById('results-data').innerHTML) // extract JSON pagination data
+                    commit('setTotal', data.total) // set the total results
+                    commit('pages/setTotal', data.pages, { root: true }) // root:true necessary to use other module
+                    commit('update', html) // update the actual result HTML
+                })
+        },
+        sort: async ({ commit, getters, rootGetters }, sort) => {
+            commit('sort', sort) // change the sort type
+            await fetch(getters.path(rootGetters.formState), ajax) // get result data from the server
+                .then(res => res.text()) // we don't need the pagination data because it stays the same
+                .then(html => commit('update', html)) // just update result HTML
+        },
+    },
+    getters: {
+        path: state => formState => `${state.endpoint}?${querystring.stringify(formState)}`, // convert the form to a querystring and make a URL
+    }
+}

--- a/sitemedia/js/store/mutations.js
+++ b/sitemedia/js/store/mutations.js
@@ -167,38 +167,6 @@ export default {
     },
 
     /**
-     * Takes an object parsed from the solr JSON response
-     * and updates the number of total results.
-     *
-     * @param {Object} state current application state
-     * @param {Object} data parsed solr response
-     */
-    updateTotalResults: (state, { total }) => {
-        state.totalResults = total
-    },
-
-    /**
-     * Takes a string parsed from the Django HTML response
-     * and updates the results.
-     *
-     * @param {Object} state current application state
-     * @param {String} results HTML response parsed into string
-     */
-    updateResults: (state, results) => {
-        state.results = results
-    },
-    
-    /**
-     * Changes the active sorting option for search results.
-     *
-     * @param {Object} state current application state
-     * @param {String} option sorting option to switch to
-     */
-    changeSort: (state, option) => {
-        state.activeSort = option
-    },
-
-    /**
      * Sets the active keyword query.
      *
      * @param {*} state
@@ -217,16 +185,5 @@ export default {
      */
     setFacetsEndpoint: (state, endpoint) => {
         state.facetsEndpoint = endpoint
-    },
-
-    /**
-     * Stores the endpoint at which the form should look to receive HTML
-     * result data from Django.
-     *
-     * @param {Object} state current application state
-     * @param {String} endpoint path to use, e.g. '/books'
-     */
-    setResultsEndpoint: (state, endpoint) => {
-        state.resultsEndpoint = endpoint
     },
 }

--- a/sitemedia/js/utilities.js
+++ b/sitemedia/js/utilities.js
@@ -1,1 +1,19 @@
 export const toArray = value => Array.isArray(value) ? value : value ? [value] : undefined
+
+export const ajax = {
+    headers: { // this header is needed to signal an ajax request to Django
+        'X-Requested-With': 'XMLHttpRequest',
+    }
+}
+export const parser = new DOMParser()
+
+export const reduceFacets = (acc, cur) => {
+    if (acc[cur.facet]) {
+        if (!Array.isArray(acc[cur.facet])) {
+            acc[cur.facet] = toArray(acc[cur.facet])
+        }
+        acc[cur.facet].push(cur.value)
+    }
+    else acc[cur.facet] = cur.value
+    return acc
+}

--- a/sitemedia/scss/snippets/_search-form.scss
+++ b/sitemedia/scss/snippets/_search-form.scss
@@ -115,10 +115,14 @@
         }
     }
 
-    .search-sort,
-    .pagination {
+    .search-sort {
+        margin-right: 1rem;
+    }
+
+    .result-controls {
         display: flex;
         align-items: center;
+        justify-content: space-between;
 
         label { // "sort by", "display", "results"
             margin-right: 1rem;

--- a/winthrop/books/templates/books/book_list.html
+++ b/winthrop/books/templates/books/book_list.html
@@ -51,6 +51,7 @@
         <div class="ui center aligned text container">
             <h4 class="results-count ui header">Showing {{ paginator.count|intcomma }} book{{ paginator.count|pluralize }}</h4>
         </div>
+        {% include 'snippets/pagination.html' %}
         {% include 'books/snippets/book_list_results.html' %}
     </noscript>
 </div>

--- a/winthrop/books/templates/books/book_list.html
+++ b/winthrop/books/templates/books/book_list.html
@@ -42,7 +42,8 @@
                 </sui-grid>
             </sui-tab-pane>
         </sui-tab>
-        <search-sort slot="sort"/>
+        <search-sort slot="sort"></search-sort>
+        <pagination slot="pagination"></pagination>
     </search-form>
     <search-results></search-results>
     <noscript>

--- a/winthrop/books/templates/books/snippets/book_list_results.html
+++ b/winthrop/books/templates/books/snippets/book_list_results.html
@@ -3,12 +3,12 @@ as part of book_list.html or requested separately via ajax to update results.
 {% endcomment %}
 
 {# pagination information for consumption in vue.js search form #}
-<pre class="results-data" style="display: none;">
+<pre id="results-data" style="display: none;">
 {
-    total: {{ page_obj.paginator.count }},
-    resultsPerPage: {{ page_obj.paginator.per_page }},
-    pages: {{ page_obj.paginator.num_pages }},
-    current: {{ page_obj.number }}
+    "total": {{ page_obj.paginator.count }},
+    "resultsPerPage": {{ page_obj.paginator.per_page }},
+    "pages": {{ page_obj.paginator.num_pages }},
+    "current": {{ page_obj.number }}
 }
 </pre>
 {% if paginator.count %}

--- a/winthrop/books/tests/test_book_views.py
+++ b/winthrop/books/tests/test_book_views.py
@@ -254,13 +254,13 @@ class TestBookViews(TestCase):
         assert len(response.context['object_list']) == books.count()
 
         # should include pagination data for vue.js search form to consume
-        self.assertContains(response, '<pre class="results-data')
-        self.assertContains(response, 'total: %d' % books.count())
-        self.assertContains(response, 'resultsPerPage: %d' % \
+        self.assertContains(response, '<pre id="results-data')
+        self.assertContains(response, '\"total\": %d' % books.count())
+        self.assertContains(response, '\"resultsPerPage\": %d' % \
             response.context['page_obj'].paginator.per_page)
-        self.assertContains(response, 'pages: %d' % \
+        self.assertContains(response, '\"pages\": %d' % \
             response.context['page_obj'].paginator.num_pages)
-        self.assertContains(response, 'current: %d' % \
+        self.assertContains(response, '\"current\": %d' % \
             response.context['page_obj'].number)
 
     @pytest.mark.usefixtures("solr")


### PR DESCRIPTION
refs #103 

## dev note
tl;dr important stuff is the `Pagination` component and `pages.js` module. it ended up being easiest to just replicate the logic from the django pagination template in js after all; upside is that we can use this pagination component on any project to get the same pagination.

I started to break out pieces of the vuex store into [modules](https://vuex.vuejs.org/guide/modules.html), which was super useful. The methods have the same API, they're just part of more self-contained units now and are namespaced, so you can do stuff like `dispatch('results/reload')` or `getters.results.total`.

I played around a little bit with modularizing the facet-related state in `modules/facets.js` but left this for later since it wasn't necessary for the pagination to work. The file isn't used by vuex currently.